### PR TITLE
Add tray icon

### DIFF
--- a/tdpmain/resource.h
+++ b/tdpmain/resource.h
@@ -1,6 +1,6 @@
 //{{NO_DEPENDENCIES}}
-// Microsoft Visual C++에서 생성한 포함 파일입니다.
-// tdpmain.rc에서 사용되고 있습니다.
+// Microsoft Visual C++?? ??? ?? ?????.
+// tdpmain.rc?? ???? ????.
 //
 #define IDI_TDPMAIN                     100
 #define IDI_SMALL                       101
@@ -18,6 +18,7 @@
 #define IDC_LBL_FONT                    1008
 #define IDC_EDIT_FONT                   1009
 #define IDC_LBL_FONT_DESC               1010
+#define IDC_CHK_MINTRAY                 1011
 #define IDC_LBL_TOP_DESC                -1
 
 // Next default values for new objects
@@ -27,7 +28,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        103
 #define _APS_NEXT_COMMAND_VALUE         32700
-#define _APS_NEXT_CONTROL_VALUE         1011
+#define _APS_NEXT_CONTROL_VALUE         1012
 #define _APS_NEXT_SYMED_VALUE           104
 #endif
 #endif

--- a/tdpmain/resource.h
+++ b/tdpmain/resource.h
@@ -1,12 +1,13 @@
 //{{NO_DEPENDENCIES}}
-// Microsoft Visual C++?? ??? ?? ?????.
-// tdpmain.rc?? ???? ????.
+// Microsoft Visual C++에서 생성한 포함 파일입니다.
+// tdpmain.rc에서 사용되고 있습니다.
 //
 #define IDI_TDPMAIN                     100
 #define IDI_SMALL                       101
 #define IDD_SETTINGS                    102
 #define IDB_ALWAYS_ON_TOP               300
 #define IDB_SETTINGS                    301
+#define IDB_TRAY_QUIT                   499
 #define IDC_LBL_POPUP_DESC              1001
 #define IDC_CHK_ALWAYS_ON_TOP           1002
 #define IDC_CHK_POPUP                   1003
@@ -27,6 +28,6 @@
 #define _APS_NEXT_RESOURCE_VALUE        103
 #define _APS_NEXT_COMMAND_VALUE         32700
 #define _APS_NEXT_CONTROL_VALUE         1011
-#define _APS_NEXT_SYMED_VALUE           103
+#define _APS_NEXT_SYMED_VALUE           104
 #endif
 #endif

--- a/tdpmain/tdpmain.rc
+++ b/tdpmain/tdpmain.rc
@@ -15,7 +15,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// 한국어(대한민국) resources
+// ???(????) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
@@ -26,30 +26,31 @@ LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 // Dialog
 //
 
-IDD_SETTINGS DIALOGEX 0, 0, 309, 218
+IDD_SETTINGS DIALOGEX 0, 0, 309, 242
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION
 CAPTION "Settings"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    DEFPUSHBUTTON   "Save",IDOK,198,198,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,252,198,50,14
-    LTEXT           "If checked, links will be opened in the system's default web browser.\r\nIf unchecked, links will be opened in an internal popup window.",IDC_LBL_POPUP_DESC,18,42,229,18,WS_DISABLED
+    DEFPUSHBUTTON   "Save",IDOK,198,222,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,252,222,50,14
+    LTEXT           "If checked, links will be opened in the system's default web browser.\r\nIf unchecked, links will be opened in an internal popup window.",IDC_LBL_POPUP_DESC,18,66,229,18,WS_DISABLED
     CONTROL         "Always On Top as Default",IDC_CHK_ALWAYS_ON_TOP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,6,99,10
     CONTROL         "Open Links in a Default Web Browser",IDC_CHK_POPUP,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,30,134,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,54,134,10
     LTEXT           "If checked, TweetDeck Player window will be set to be always on top on startup.",IDC_LBL_TOP_DESC,18,18,259,8,WS_DISABLED
     CONTROL         "Don't Show ""Write Tweet in Twitter"" Context Menu",IDC_CHK_CTX_TWEET_IN_TWITTER,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,66,178,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,90,178,10
     CONTROL         "Don't Show ""Open Twitter in Popup"" Context Menu",IDC_CHK_CTX_TWITTER_POPUP,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,84,178,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,108,178,10
     CONTROL         "Don't Show ""Open Link in Popup"" Context Menu",IDC_CHK_CTX_LINK_POPUP,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,102,167,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,126,167,10
     CONTROL         "Don't Download Images in Original Quality",IDC_CHK_DL_ORIG_IMG,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,120,149,10
-    LTEXT           "If checked, TweetDeck Player will download images in ""large"" quality.",IDC_LBL_TOP_DESC,18,132,221,8,WS_DISABLED
-    LTEXT           "Display Font:",IDC_LBL_FONT,6,151,43,8
-    EDITTEXT        IDC_EDIT_FONT,54,150,246,12,ES_AUTOHSCROLL
-    LTEXT           "Leave it blank if you want to use the default font.\r\nYou need to restart TweetDeck Player to apply new fonts.",IDC_LBL_FONT_DESC,54,166,204,20,WS_DISABLED
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,144,149,10
+    LTEXT           "If checked, TweetDeck Player will download images in ""large"" quality.",IDC_LBL_TOP_DESC,18,156,221,8,WS_DISABLED
+    LTEXT           "Display Font:",IDC_LBL_FONT,6,175,43,8
+    EDITTEXT        IDC_EDIT_FONT,54,174,246,12,ES_AUTOHSCROLL
+    LTEXT           "Leave it blank if you want to use the default font.\r\nYou need to restart TweetDeck Player to apply new fonts.",IDC_LBL_FONT_DESC,54,190,204,20,WS_DISABLED
+    CONTROL         "Minimize to System Tray",IDC_CHK_MINTRAY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,36,93,10
 END
 
 
@@ -66,17 +67,17 @@ BEGIN
         LEFTMARGIN, 7
         RIGHTMARGIN, 302
         TOPMARGIN, 7
-        BOTTOMMARGIN, 211
+        BOTTOMMARGIN, 235
     END
 END
 #endif    // APSTUDIO_INVOKED
 
-#endif    // 한국어(대한민국) resources
+#endif    // ???(????) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// 영어(미국) resources
+// ??(??) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
@@ -160,7 +161,7 @@ END
 
 #endif    // APSTUDIO_INVOKED
 
-#endif    // 영어(미국) resources
+#endif    // ??(??) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/tdpmain/tdpmain.rc
+++ b/tdpmain/tdpmain.rc
@@ -15,7 +15,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// ???(????) resources
+// 한국어(대한민국) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
@@ -71,12 +71,12 @@ BEGIN
 END
 #endif    // APSTUDIO_INVOKED
 
-#endif    // ???(????) resources
+#endif    // 한국어(대한민국) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// ??(??) resources
+// 영어(미국) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
@@ -160,7 +160,7 @@ END
 
 #endif    // APSTUDIO_INVOKED
 
-#endif    // ??(??) resources
+#endif    // 영어(미국) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/tdpmain/tdpmain_window.cc
+++ b/tdpmain/tdpmain_window.cc
@@ -55,8 +55,12 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 				switch (wParam)
 				{
 					case SC_MINIMIZE:
-						HideToTray(hWnd);
-						return 0;
+						if (GetINI_Int(L"setting", L"MinimizeToTray", 1))
+						{
+							HideToTray(hWnd);
+							return 0;
+						}
+						else break;
 					case SC_MAXIMIZE:
 					{
 						RECT rect;
@@ -173,6 +177,7 @@ BOOL CALLBACK TDPWindow::SettingsDlgProc(HWND hWnd, UINT message, WPARAM wParam,
 
 		// Read settings from appdata.ini and set controls appropriately.
 		CheckDlgButton(hWnd, IDC_CHK_ALWAYS_ON_TOP, GetINI_Int(L"setting", L"DefaultAlwaysOnTop", 0));
+		CheckDlgButton(hWnd, IDC_CHK_MINTRAY, GetINI_Int(L"setting", L"MinimizeToTray", 1));
 		CheckDlgButton(hWnd, IDC_CHK_POPUP, GetINI_Int(L"setting", L"DisableLinkPopup", 0));
 		CheckDlgButton(hWnd, IDC_CHK_CTX_TWEET_IN_TWITTER, GetINI_Int(L"setting", L"DisableWriteTweetMenu", 0));
 		CheckDlgButton(hWnd, IDC_CHK_CTX_TWITTER_POPUP, GetINI_Int(L"setting", L"DisableTwitterOpenMenu", 0));
@@ -189,6 +194,7 @@ BOOL CALLBACK TDPWindow::SettingsDlgProc(HWND hWnd, UINT message, WPARAM wParam,
 		case IDOK:
 			// Write settings to appdata.ini
 			SetINI_Int(L"setting", L"DefaultAlwaysOnTop", IsDlgButtonChecked(hWnd, IDC_CHK_ALWAYS_ON_TOP));
+			SetINI_Int(L"setting", L"MinimizeToTray", IsDlgButtonChecked(hWnd, IDC_CHK_MINTRAY));
 			SetINI_Int(L"setting", L"DisableLinkPopup", IsDlgButtonChecked(hWnd, IDC_CHK_POPUP));
 			SetINI_Int(L"setting", L"DisableWriteTweetMenu", IsDlgButtonChecked(hWnd, IDC_CHK_CTX_TWEET_IN_TWITTER));
 			SetINI_Int(L"setting", L"DisableTwitterOpenMenu", IsDlgButtonChecked(hWnd, IDC_CHK_CTX_TWITTER_POPUP));

--- a/tdpmain/tdpmain_window.cc
+++ b/tdpmain/tdpmain_window.cc
@@ -19,6 +19,31 @@ TDPWindow::~TDPWindow()
 {
 }
 
+void TDPWindow::HideToTray(HWND hWnd)
+{
+	long exstyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+	exstyle |= WS_EX_TOOLWINDOW;
+	exstyle &= ~WS_EX_APPWINDOW;
+
+	ShowWindow(hWnd, SW_HIDE);
+	SetWindowLong(hWnd, GWL_EXSTYLE, exstyle);
+	ShowWindow(hWnd, SW_SHOW);
+	ShowWindow(hWnd, SW_HIDE);
+}
+
+void TDPWindow::RestoreFromTray(HWND hWnd)
+{
+	long exstyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+	if (exstyle & WS_EX_TOOLWINDOW)
+	{
+		exstyle |= WS_EX_APPWINDOW;
+		exstyle &= ~WS_EX_TOOLWINDOW;
+		SetWindowLong(hWnd, GWL_EXSTYLE, exstyle);
+	}
+	ShowWindow(hWnd, SW_RESTORE);
+	SetForegroundWindow(hWnd);
+}
+
 // static
 LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 	WPARAM wParam, LPARAM lParam) {
@@ -30,6 +55,8 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 				switch (wParam)
 				{
 					case SC_MINIMIZE:
+						HideToTray(hWnd);
+						return 0;
 					case SC_MAXIMIZE:
 					{
 						RECT rect;
@@ -45,8 +72,7 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 				switch (lParam)
 				{
 					case WM_LBUTTONDBLCLK:
-						ShowWindow(hWnd, SW_RESTORE);
-						SetForegroundWindow(hWnd);
+						RestoreFromTray(hWnd);
 						break;
 					case WM_RBUTTONUP:
 					{
@@ -110,7 +136,7 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 		}
 		break;
 		case IDB_SETTINGS:
-			ShowWindow(hWnd, SW_RESTORE);
+			RestoreFromTray(hWnd);
 			DialogBox(NULL, MAKEINTRESOURCE(IDD_SETTINGS), hWnd, (DLGPROC)SettingsDlgProc);
 			break;
 

--- a/tdpmain/tdpmain_window.h
+++ b/tdpmain/tdpmain_window.h
@@ -9,6 +9,9 @@
 
 #include "include/base/cef_scoped_ptr.h"
 
+#define NOTIFYICON_ID_MAIN 0
+#define MSG_NOTIFYICON 0x8100
+
 namespace tdpmain
 {
 
@@ -32,5 +35,6 @@ private:
 
 	static BOOL CALLBACK SettingsDlgProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 };
+
 }
 #endif

--- a/tdpmain/tdpmain_window.h
+++ b/tdpmain/tdpmain_window.h
@@ -29,6 +29,9 @@ private:
 	static HWND hMainWnd;
 	static HWND hPopupWnd;
 
+	static void HideToTray(HWND hWnd);
+	static void RestoreFromTray(HWND hWnd);
+
 	// Window procedure for the root window.
 	static LRESULT CALLBACK PopupWndProc(HWND hWnd, UINT message, WPARAM wParam,
 		LPARAM lParam);


### PR DESCRIPTION
이슈 #2 에 대응하는 트레이 아이콘 기능을 만들어 봤습니다. 현재 기본적인 기능만 구현되어 있습니다.

* 시스템 트레이 영역에 아이콘 표시
* 아이콘을 왼쪽 더블 클릭하면 메인 윈도우 복귀 및 활성화 (앞으로 가져옴)
* 아이콘을 오른쪽 클릭하면 컨텍스트 메뉴 표시
    * 설정 대화상자 열기
    * 프로그램 종료
* 프로그램이 정상적으로 종료될 때 자동으로 트레이 영역에서 아이콘 제거

![capture](https://cloud.githubusercontent.com/assets/2667858/14607315/062ca114-05bc-11e6-99a4-a0855ce14ca1.PNG)

WinAPI 트레이 아이콘에서 지원하는 기능이 윈도우의 버전에 따라 다소 차이가 있으나 최대한 하위 호환성을 고려하여 코딩했습니다. 그래도 검토할 때 Windows XP 환경에서 한번 테스트 해 주시기 바랍니다.