### PR TITLE
Prevent the main window from shrinking in some situations

### DIFF
--- a/tdpmain/tdpmain_window.cc
+++ b/tdpmain/tdpmain_window.cc
@@ -42,7 +42,13 @@ void TDPWindow::RestoreFromTray(HWND hWnd)
 		exstyle &= ~WS_EX_TOOLWINDOW;
 		SetWindowLong(hWnd, GWL_EXSTYLE, exstyle);
 	}
-	ShowWindow(hWnd, SW_RESTORE);
+
+	WINDOWPLACEMENT wndpl;
+	wndpl.length = sizeof(WINDOWPLACEMENT);
+	GetWindowPlacement(hWnd, &wndpl);
+	if (wndpl.showCmd != SW_SHOWMAXIMIZED)
+		ShowWindow(hWnd, SW_RESTORE);
+
 	SetForegroundWindow(hWnd);
 }
 
@@ -143,11 +149,7 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 		break;
 		case IDB_SETTINGS:
 		{
-			WINDOWPLACEMENT wndpl;
-			wndpl.length = sizeof(WINDOWPLACEMENT);
-			GetWindowPlacement(hWnd, &wndpl);
-			if (wndpl.showCmd != SW_SHOWMAXIMIZED)
-				RestoreFromTray(hWnd);
+			RestoreFromTray(hWnd);
 			TDPSettingsDlg::ShowDialog(hWnd);
 		}	break;
 

--- a/tdpmain/tdpmain_window.cc
+++ b/tdpmain/tdpmain_window.cc
@@ -142,9 +142,14 @@ LRESULT CALLBACK TDPWindow::PopupWndProc(HWND hWnd, UINT message,
 		}
 		break;
 		case IDB_SETTINGS:
-			RestoreFromTray(hWnd);
+		{
+			WINDOWPLACEMENT wndpl;
+			wndpl.length = sizeof(WINDOWPLACEMENT);
+			GetWindowPlacement(hWnd, &wndpl);
+			if (wndpl.showCmd != SW_SHOWMAXIMIZED)
+				RestoreFromTray(hWnd);
 			TDPSettingsDlg::ShowDialog(hWnd);
-			break;
+		}	break;
 
 		// TRAY MENU HANDLERS //
 		case IDB_TRAY_QUIT:


### PR DESCRIPTION
메인 창이 최대화되어있는 상태에서 설정 창을 열 경우 최소화 상태가 해제되어 창의 크기가 작아진다는 것을 확인했습니다. 창이 작업 표시줄 또는 트레이에 최소화되어 있는 상태에서 설정 창을 열 때 올바르게 동작하도록 하는 코드가 원인이며, 그 부분에 창이 최대화 상태인지를 검사하는 코드를 삽입하여 보완하였습니다.

*추가: 이 문제는 메인 창이 최대화되어있는 상태에서 트레이 아이콘을 더블 클릭 하였을때도 발생함을 확인했습니다. 이 문제 또한 해결할 수 있도록 코드를 옮겼습니다.*