### PR TITLE
Add electron dependency on package.json and npm start script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ version
 !*.js
 !package.json
 !tweetdeck.ico
+
+# NodeJS files
+node_modules
+*.log

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0",
   "main": "index.js",
   "dependencies": {
+    "electron": "^1.3.1",
     "request": "^2.74.0"
+  },
+  "scripts": {
+    "start": "node_modules/.bin/electron index.js"
   }
 }


### PR DESCRIPTION
npm start script and electron dependency is added in package.json

So, following command sequence can be used to launch TweetDeckPlayer.
```
# Install dependency.
npm install
# Start TweetDeckPlayer using electron.
npm start
```

Note: Need testing in MS Windows. Since Windows uses backslash rather then slash for their path encoding, it may fail if npm does not handle it properly.