### PR TITLE
Execute eslint by npm run

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "electron": "^1.4.0",
     "electron-packager": "^8.0.0",
+    "eslint": "^3.5.0",
     "rimraf": "^2.5.4"
   },
   "repository": {
@@ -39,6 +40,7 @@
     "url": "http://github.com/sokcuri/TweetDeckPlayer"
   },
   "scripts": {
+    "eslint": "eslint src/ tools/",
     "start": "node_modules/.bin/electron ./src/index.js",
     "build": "node tools/build.js",
     "clean": "node tools/clean.js"


### PR DESCRIPTION
Run `npm run eslint` to use.
To pass arguments, place them after `npm run eslint --`.
For example, if you want to `eslint src/ tools/ --fix`,
run `npm run eslint -- --fix`.