### PR TITLE
Omitted path for npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "http://github.com/sokcuri/TweetDeckPlayer"
   },
   "scripts": {
-    "start": "node_modules/.bin/electron ./src/index.js",
+    "start": "electron ./src/index.js",
     "build": "node tools/build.js",
     "clean": "node tools/clean.js"
   }


### PR DESCRIPTION
The path `node_modules/.bin/` can be omitted in `package.json`.