### PR TITLE
Added csscomb

### DIFF
--- a/.csscomb.json
+++ b/.csscomb.json
@@ -1,0 +1,23 @@
+{
+    "remove-empty-rulesets": true,
+    "always-semicolon": true,
+    "color-case": "lower",
+    "block-indent": "  ",
+    "color-shorthand": true,
+    "element-case": "lower",
+    "eof-newline": true,
+    "quotes": "single",
+    "space-before-colon": "",
+    "space-after-colon": " ",
+    "space-before-combinator": " ",
+    "space-after-combinator": " ",
+    "space-between-declarations": "\n",
+    "space-before-opening-brace": " ",
+    "space-after-opening-brace": "\n",
+    "space-after-selector-delimiter": " ",
+    "space-before-selector-delimiter": "",
+    "space-before-closing-brace": "\n",
+    "strip-spaces": true,
+    "tab-size": 2,
+    "unitless-zero": true
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "csscomb": "^3.1.8",
     "electron": "^1.4.0",
     "electron-packager": "^8.0.0",
     "eslint": "^3.5.0",
@@ -41,6 +42,8 @@
     "url": "http://github.com/sokcuri/TweetDeckPlayer"
   },
   "scripts": {
+    "csslint": "csscomb src/css/ --lint --verbose",
+    "csscomb": "csscomb src/css/ --verbose",
     "start": "electron ./src/index.js",
     "eslint": "eslint src/ tools/",
     "build": "node tools/build.js",


### PR DESCRIPTION
csscomb beautifies css files.
Run `npm run csscomb` to use it.
`npm run csslint` shows what files need to be fixed,
but it doesn't show what's wrong, which is not helpful.
The csscomb's developer might update it someday, though.