### PR TITLE
Feature/improved build system

### DIFF
--- a/.buildignore.js
+++ b/.buildignore.js
@@ -1,0 +1,13 @@
+module.exports = [
+  '.buildignore.js',
+  '.csscomb.json',
+  '.editorconfig',
+  '.eslintignore',
+  '.eslintrc.js',
+  '.gitignore',
+  'ChangeLog.md',
+  'LICENSE',
+  'README.md',
+  'tools',
+];
+

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ data/
 
 # Build Results
 build/
+dist/
 
 # asar files
 *.asar

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "csscomb": "^3.1.8",
     "electron-packager": "^8.0.0",
     "eslint": "^3.5.0",
-    "rimraf": "^2.5.4"
+    "fs-extra": "^0.30.0",
+    "minimist": "^1.2.0",
+    "sync-exec": "^0.6.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "version": "2.0.1",
   "main": "src/index.js",
   "dependencies": {
+    "electron": "^1.4.0",
     "async": "^2.0.1",
     "detect-font": "^0.1.3",
     "jquery": "^3.1.0",
@@ -32,7 +33,6 @@
   "license": "MIT",
   "devDependencies": {
     "csscomb": "^3.1.8",
-    "electron": "^1.4.0",
     "electron-packager": "^8.0.0",
     "eslint": "^3.5.0",
     "rimraf": "^2.5.4"

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,66 +1,92 @@
+const exec = require('sync-exec');
+const fs = require('fs-extra');
+const parseArgs = require('minimist');
 const packager = require('electron-packager');
 const path = require('path');
-const fs = require('fs');
 
 const projectDir = path.resolve(__dirname, '..');
-const outputDir = path.join(projectDir, 'build');
-const dataDir = path.join(projectDir, 'src/data');
+const intermediateDir = path.join(projectDir, 'build');
+const distDir = path.join(projectDir, 'dist');
 
-const copyFile = (source, dest) => {
-    fs.createReadStream(source).pipe(fs.createWriteStream(dest));
+const prebuild = () => {
+  console.log('--- Prebuild Started ---');
+  const wd = process.cwd();
+  const buildIgnore = require('../.buildignore.js');
+
+  fs.removeSync(intermediateDir);
+  fs.removeSync(distDir);
+  fs.mkdirSync(intermediateDir);
+  fs.mkdirSync(distDir);
+
+  // copy clean project directory
+  console.log('Copying clean project directory to build directory...');
+  process.chdir(projectDir);
+  exec('git --work-tree=./build/ checkout --force');
+
+  process.chdir(intermediateDir);
+
+  // remove unnecessary files from intermediate
+  console.log('Removing unnecessary files...');
+  for (const ignoredFile of buildIgnore) {
+    fs.removeSync(ignoredFile);
+  }
+
+  // install production packages
+  console.log('Installing production packages...');
+  exec('npm install --production');
+
+  console.log('--- Prebuild Done ---');
+  process.chdir(wd);
 };
 
-const buildOne = (targetOptions) => {
-    const baseOption = {
-        dir: projectDir,
-        out: outputDir,
-        asar: true,
-        overwrite: true,
-        ignore: [
-            dataDir,
-            outputDir
-        ]
-    };
-    const option = Object.assign({}, baseOption, targetOptions);
-    packager(option, (err, appPaths) => {
-        if (!!err) {
-            console.error(err);
-        } else {
-            const appPath = appPaths[0];
-            fs.unlink(path.join(appPath, 'version'));
-            copyFile(path.join(projectDir, 'LICENSE'), path.join(appPath, 'LICENSE'));
-            copyFile(path.join(projectDir, 'README.md'), path.join(appPath, 'README.md'));
-            copyFile(path.join(projectDir, 'ChangeLog.md'), path.join(appPath, 'ChangeLog.md'));
-        }
-    });
+const postSingleBuild = appPath => {
+  fs.removeSync(path.join(appPath, 'version'));
+  fs.copySync(path.join(projectDir, 'LICENSE'), path.join(appPath, 'LICENSE'));
+  fs.copySync(path.join(projectDir, 'README.md'), path.join(appPath, 'README.md'));
+  fs.copySync(path.join(projectDir, 'ChangeLog.md'), path.join(appPath, 'ChangeLog.md'));
 };
 
-const presets = [
-    {
-        platform: 'darwin',
-        arch: 'x64',
-        icon: 'src/tweetdeck.icns'
+const build = () => {
+  const options = parseArgs(process.argv.slice(2), {
+    string: ['platform', 'arch'],
+    boolean: 'all',
+    default: {
+      all: false,
+      platform: process.platform,
+      arch: process.arch,
     },
-    {
-        platform: 'win32',
-        arch: 'ia32',
-        icon: 'src/tweetdeck.ico'
-    },
-    {
-        platform: 'win32',
-        arch: 'x64',
-        icon: 'src/tweetdeck.ico'
-    },
-    {
-        platform: 'linux',
-        arch: 'ia32'
-    },
-    {
-        platform: 'linux',
-        arch: 'x64'
+  });
+  if (options.all) {
+    options.platform = 'all';
+    options.arch = 'all';
+  }
+  const packagerOptions = {
+    dir: intermediateDir,
+    out: distDir,
+    asar: true,
+    overwrite: true,
+    icon: 'src/tweetdeck',
+    platform: options.platform,
+    arch: options.arch,
+  };
+
+  console.log('--- Build Started ---');
+
+  packager(packagerOptions, (err, appPaths) => {
+    if (!!err) {
+      console.error(err);
+      process.exit(1);
+    } else {
+      for (const appPath of appPaths) {
+        postSingleBuild(appPath);
+        console.log(`* ${appPath}`);
+      }
+      console.log('--- Build Done ---');
     }
-];
+  });
+};
 
-for (const preset of presets) {
-    buildOne(preset);
+if (require.main === module) {
+  prebuild();
+  build();
 }

--- a/tools/clean.js
+++ b/tools/clean.js
@@ -1,7 +1,6 @@
+const fs = require('fs-extra');
 const path = require('path');
-const rimraf = require('rimraf');
 
-rimraf(path.resolve(__dirname, '../build'), () => {
-    console.log('Cleaned');
-});
-
+fs.removeSync(path.resolve(__dirname, '../build'));
+fs.removeSync(path.resolve(__dirname, '../dist'));
+console.log('Cleaned');


### PR DESCRIPTION
`npm run build` now runs like `electron-packaer`.
`npm run build -- --all` builds for all platforms and architectures.
To build for specific platforms and architectures,
run `npm run build -- --platform=<platform> --arch=<arch>`.
`<platform>` and `<arch>` can be string or comma-delimited string for multiple targets.
If not specified, the platform/arch of the host computer running Node is used.
e.g. `npm run build` without any argument will build for your machine's platform and architecture.
For the detail, note https://github.com/electron-userland/electron-packager/blob/master/docs/api.md