### PR TITLE
클립보드 붙여넣기 기능 개선

### DIFF
--- a/src/preload_scripts/clipboard-paste.js
+++ b/src/preload_scripts/clipboard-paste.js
@@ -2,18 +2,19 @@
 // https://gist.github.com/zn/4f622ba80513e0f4d0dd3f13dcd085db
 
 module.exports = function enablePaste () {
-  let jq = window.$;
-  jq(document.body).on('paste', event => {
-    if (jq('.js-add-image-button').hasClass('is-disabled')) {
-      return;
+  $(document.body).on('paste', event => {
+    if ($('.js-add-image-button').hasClass('is-disabled')) return;
+    const items = event.originalEvent.clipboardData.items;
+    const images = [...items].filter(item => item.type.search('image/') === 0);
+    if (images.length > 0) {
+      event.preventDefault();
+      for (const image of images) {
+        const files = [ image.getAsFile() ];
+        if (!$('.app-content').hasClass('is-open')) {
+          $(document).trigger('uiComposeTweet', { type: 'tweet' });
+        }
+        $(document).trigger('uiFilesAdded', { files });
+      }
     }
-    var items = event.originalEvent.clipboardData.items;
-    var item = items[0];
-    if (item.kind !== 'file') return;
-    var files = [ item.getAsFile() ];
-    if (!jq('.app-content').hasClass('is-open')) {
-      jq(document).trigger('uiComposeTweet', { type: 'tweet' });
-    }
-    jq(document).trigger('uiFilesAdded', { files });
   });
 };


### PR DESCRIPTION
파이어폭스나 크롬등에서 복사한 이미지를 트윗덱 플레이어에 붙여넣기할 때, 두 가지 데이터가 들어오는 경우(`<img>` 태그 형식의 `text/html` 데이터 & 실제 이미지 데이터)가 있는데, 이를 제대로 처리하지 못 한게 원인.
이런 현상을 고치기 위한 커밋