### PR TITLE
useCircleProfileImage 옵션 버그 수정

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,7 @@ module.exports = {
     altImageViewer: 'on',
     enableOpenLinkinPopup: 'on',
     enableOpenImageinPopup: 'on',
+    useCircleProfileImage: false,
   },
   data: {},
   load () {


### PR DESCRIPTION
config.json에 useCircleProfileImage 옵션을 설정하지 않으면 true로 인식되는 버그 수정

true든 false든 기본값을 정해줄 필요가 있어 보입니다. 그렇지 않으면 (원래 의도와 다르게) false가 아닌 null로 인식되어, 실제로는 true로 toggle됩니다.