### PR TITLE
"이미지 클릭 시 다음 이미지 보기"를 설정에 추가

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ module.exports = {
     customizeColumnSize: '310',
     quoteServer: 'https://quote.sapphire.sh',
     altImageViewer: 'on',
+    tivClickForNextImage: 'on',
     enableOpenLinkinPopup: 'on',
     enableOpenImageinPopup: 'on',
     useCircleProfileImage: false,

--- a/src/css/extra.css
+++ b/src/css/extra.css
@@ -97,6 +97,8 @@
   max-width: 100%;
   transition: filter .3s;
   will-change: filter;
+}
+.tiv-image.click-enabled {
   cursor: url('data:image/svg+xml,<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><g style="stroke-width:7px;stroke:black"><path d="M 2 16 L 27 16 Z" /><path d="M 14.293 3.293 L 27 16 L 14.293 28.707 L 27 16 Z" /></g><g style="stroke-width:5px;stroke:white"><path d="M 3 16 L 27 16 Z" /><path d="M 15 4 L 27 16 L 15 28 L 27 16 Z" /></g></svg>') 16 16, pointer;
 }
 .tiv-image.loading {

--- a/src/preload_scripts/image-viewer.js
+++ b/src/preload_scripts/image-viewer.js
@@ -50,7 +50,7 @@ class TDPImageViewer {
       image.classList.remove('loading');
     });
     image.addEventListener('click', event => {
-      this.circleNext();
+      config.tivClickForNextImage ? this.circleNext() : false;
     });
     toolbar.querySelector('.tiv-btn-prev').addEventListener('click', event => {
       event.preventDefault();
@@ -94,6 +94,12 @@ class TDPImageViewer {
   }
   show () {
     this.viewer.style.display = 'flex';
+    if (config.tivClickForNextImage) {
+      this.image.classList.add('click-enabled');
+    }
+    else {
+      this.image.classList.remove('click-enabled');
+    }
   }
   close () {
     this.viewer.style.display = 'none';

--- a/src/setting.html
+++ b/src/setting.html
@@ -258,6 +258,13 @@
                   Use alternative image viewer
                 </label>
               </div>
+              <div class="settings-item">
+                <label>
+                  <input type="checkbox" id="tivClickForNextImage"><label for="tivClickForNextImage"><div></div></label>
+                  Click the image to cycle through images
+                </label>
+              </div>
+              <div class="settings-item description for-checkbox">You can still move forward or backward through images using the buttons on top of the screen.</div>
               <div class="settings-item sub-header">Privacy</div>
               <div class="settings-item">
                 <label>


### PR DESCRIPTION
(with regarding to: #77)

TDP 설정에 "이미지 클릭 시 다음 이미지 보기" 옵션을 추가했습니다.

* 켜져 있을 경우 #78 PR에서 구현한 대로 이미지 뷰어에서 이미지를 클릭하면 다음 이미지를 표시합니다.
* 꺼져 있을 경우 해당 기능이 동작하지 않으며, 이미지 위에 마우스 커서를 올려도 커서 모양이 바뀌지 않습니다.