### PR TITLE
트윗 왼쪽에 RT/마음 상태에 따라 색상띠 표시

### DIFF
--- a/src/css/extra.css
+++ b/src/css/extra.css
@@ -146,12 +146,12 @@ body.tdp-color-labels .tdp-color-label {
   width: 3px;
   height: 100%;
 }
-body.tdp-color-labels .js-tweet.tweet.is-favorite .tdp-color-label {
+body.tdp-color-labels .js-tweet.tweet.is-favorite+.tdp-color-label {
   background-color: #fab41e;
 }
-body.tdp-color-labels .js-tweet.tweet.is-retweet .tdp-color-label {
+body.tdp-color-labels .js-tweet.tweet.is-retweet+.tdp-color-label {
   background-color: #19cf86;
 }
-body.tdp-color-labels .js-tweet.tweet.is-favorite.is-retweet .tdp-color-label {
+body.tdp-color-labels .js-tweet.tweet.is-favorite.is-retweet+.tdp-color-label {
   background-color: #3b94d9;
 }

--- a/src/css/extra.css
+++ b/src/css/extra.css
@@ -137,3 +137,21 @@
   opacity: .6;
   cursor: not-allowed;
 }
+
+/* 트윗 상태(리트윗, 마음) 표시 */
+body.tdp-color-labels .tdp-color-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+}
+body.tdp-color-labels .js-tweet.tweet.is-favorite .tdp-color-label {
+  background-color: #fab41e;
+}
+body.tdp-color-labels .js-tweet.tweet.is-retweet .tdp-color-label {
+  background-color: #19cf86;
+}
+body.tdp-color-labels .js-tweet.tweet.is-favorite.is-retweet .tdp-color-label {
+  background-color: #3b94d9;
+}

--- a/src/preload.js
+++ b/src/preload.js
@@ -89,6 +89,13 @@ ipcRenderer.on('apply-config', event => {
 
     style += `--column-size: ${config.customizeColumnSize}px;`;
 
+    if (config.showColorLabels) {
+      cl.add('tdp-color-labels');
+    }
+    else {
+      cl.remove('tdp-color-labels');
+    }
+
     document.body.style = style;
   } catch (e) {
     console.warn(e);
@@ -297,6 +304,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // inject tdp settings menu
     window.TD_mustaches['menus/topbar_menu.mustache'] = window.TD_mustaches['menus/topbar_menu.mustache'].replace('Settings{{/i}}</a> </li>', 'Settings{{/i}}</a> </li> <li class="is-selectable"><a href="#" data-action="tdpSettings">{{_i}}TweetDeck Player Settings{{/i}}</a></li>');
+
+    // inject tweet indicator label
+    window.TD_mustaches['status/tweet_single.mustache'] = window.TD_mustaches['status/tweet_single.mustache'].replace(/<\/div>$/, '<div class="tdp-color-label"></div></div>');
   }
 
   if (document.title === 'TweetDeck') {

--- a/src/preload.js
+++ b/src/preload.js
@@ -306,7 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.TD_mustaches['menus/topbar_menu.mustache'] = window.TD_mustaches['menus/topbar_menu.mustache'].replace('Settings{{/i}}</a> </li>', 'Settings{{/i}}</a> </li> <li class="is-selectable"><a href="#" data-action="tdpSettings">{{_i}}TweetDeck Player Settings{{/i}}</a></li>');
 
     // inject tweet indicator label
-    window.TD_mustaches['status/tweet_single.mustache'] = window.TD_mustaches['status/tweet_single.mustache'].replace(/<\/div>$/, '<div class="tdp-color-label"></div></div>');
+    window.TD_mustaches['status/tweet_single.mustache'] = window.TD_mustaches['status/tweet_single.mustache'].replace(/<\/div>$/, '</div><div class="tdp-color-label"></div>');
   }
 
   if (document.title === 'TweetDeck') {

--- a/src/setting.html
+++ b/src/setting.html
@@ -166,6 +166,12 @@
               <div class="settings-item description for-checkbox">
                 Press Shift+Enter to insert a line break.
               </div>
+              <div class="settings-item">
+                <label>
+                  <input type="checkbox" id="showColorLabels"><label for="showColorLabels"><div></div></label>
+                  Show Color Labels
+                </label>
+              </div>
               <div class="settings-item sub-header">Context Menu</div>
               <div class="settings-item">
                 <label>


### PR DESCRIPTION
#32 이슈에서 제안한 기능을 구현하였고, 설정에서 켜고 끌 수 있게 했습니다.

## 미리보기
![2017-03-01 16-51-52](https://cloud.githubusercontent.com/assets/2667858/23450596/6df02c8a-fe9f-11e6-994c-3cbc3980b86d.png)

* 각각 리트윗/마음/리트윗+마음
* 마음에 드는 트윗은 하트/별 상관 없이 노란색입니다. 추후에 색상 커스터마이징 하는 옵션 넣으면 될듯