### PR TITLE
switch account fix (세벌식 bug)

### DIFF
--- a/src/preload_scripts/switch-account.js
+++ b/src/preload_scripts/switch-account.js
@@ -3,7 +3,7 @@ function SwitchAccount () {
   document.addEventListener('keyup', event => {
     if (!event.ctrlKey) return;
     if (!/Digit\d/.test(event.code)) return;
-    let key = parseInt(event.key, 10);
+    let key = parseInt(event.keyCode, 10)-48;
     if (Number.isNaN(key)) return;
     key = (key === 0 ? 10 : (key - 1));
     const accounts = $('.js-account-list .js-account-item');


### PR DESCRIPTION
OS X에서 세벌식 자판을 사용하는 경우, switch account 기능이 동작하지 않는 bug가 있었습니다.
keyCode값은 똑같지만 key값은 세벌식 자판 배열에 맞춰서 나왔기 때문에, key가 NaN으로 인식되는 문제가 있었고 해당 부분을 수정했습니다.
테스트는 Mac OS sierra에서 진행하였습니다.