### PR TITLE
addMessage 에러 해결 (+ 외 1)

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -191,13 +191,6 @@ module.exports = [
   { _type: 'subsection', label: 'Feature' },
   {
     _type: 'entry',
-    name: 'useOldStyleReply',
-    valueType: 'bool',
-    label: 'Use Old-style Reply',
-    description: '<b>Requires reload to apply.</b>',
-  },
-  {
-    _type: 'entry',
     name: 'useCounterClear',
     valueType: 'bool',
     label: 'Clear notification counter periodically',

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,6 @@ module.exports = {
     enableOpenLinkinPopup: 'on',
     enableOpenImageinPopup: 'on',
     useSquareProfileImage: false,
-    useOldStyleReply: false,
     useCounterClear: false,
   },
   data: {},

--- a/src/preload.js
+++ b/src/preload.js
@@ -156,13 +156,13 @@ ipcRenderer.on('command', (event, cmd) => {
       document.execCommand('selectall');
       break;
     case 'copyimage':
-      window.TD.controller.progressIndicator.addMessage('Image downloading..');
+      window.toastMessage('Image downloading..');
       const nativeImage = require('electron').nativeImage;
       var request = require('request').defaults({ encoding: null });
       request.get(Addr.img, function (error, response, body) {
         if (!error && response.statusCode === 200) {
           clipboard.writeImage(nativeImage.createFromBuffer(body));
-          window.TD.controller.progressIndicator.addMessage('Image copied to clipboard');
+          window.toastMessage('Image copied to clipboard');
         }
       });
       break;
@@ -204,7 +204,7 @@ ipcRenderer.on('command', (event, cmd) => {
     case 'copy-tweet': {
       const text = Addr.text;
       clipboard.writeText(text);
-      window.TD.controller.progressIndicator.addMessage(window.TD.i('Copied text "{{text}}" ! ', { text }));
+      window.toastMessage(window.TD.i('Copied text "{{text}}" ! ', { text }));
     } break;
     case 'copy-tweet-with-author': {
       const el = document.querySelector(`article[data-tweet-id="${Addr.id}"]`);
@@ -214,7 +214,7 @@ ipcRenderer.on('command', (event, cmd) => {
         text += ` (by ${userid.textContent})`;
       }
       clipboard.writeText(text);
-      window.TD.controller.progressIndicator.addMessage(window.TD.i('Copied text "{{text}}" ! ', { text }));
+      window.toastMessage(window.TD.i('Copied text "{{text}}" ! ', { text }));
     } break;
     case 'open-google-translator': {
       ipcRenderer.send('open-google-translator', {
@@ -348,6 +348,20 @@ document.addEventListener('dragstart', evt => {
 document.addEventListener('DOMContentLoaded', () => {
   const TD = window.TD;
   const $ = window.$;
+
+  window.toastMessage = message => {
+    window.webpackJsonp([0], [(a, b, c) => {
+      const toaster = c(8);
+      toaster.showNotification({ message });
+    }]);
+  };
+
+  window.toastErrorMessage = message => {
+    window.webpackJsonp([0], [(a, b, c) => {
+      const toaster = c(8);
+      toaster.showErrorNotification({ message });
+    }]);
+  };
 
   function patchContentEditable () {
     $('[contenteditable="true"]').css({
@@ -485,7 +499,7 @@ document.addEventListener('DOMContentLoaded', () => {
       var s = function (e) {
         var t = TD.core.defer.fail();
         if (403 === e.status || 404 === e.status) {
-          TD.controller.progressIndicator.addMessage((r ? TD.i('Failed: Unretweet -') : TD.i('Failed: Retweet -')) + ' ' + JSON.parse(e.responseText).errors[0].message);
+          window.toastErrorMessage((r ? TD.i('Failed: Unretweet -') : TD.i('Failed: Retweet -')) + ' ' + JSON.parse(e.responseText).errors[0].message);
         }
         403 !== e.status && 404 !== e.status || (t = this.refreshRetweet(o)),
         t.addErrback(function () {
@@ -550,7 +564,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // TweetDeck Ready Check
   $(document).on('TD.ready', () => {
     ipcRenderer.send('page-ready-tdp', this);
-    TD.controller.progressIndicator.addMessage(TD.i(VERSION));
+    window.toastMessage(TD.i(VERSION));
     setTimeout(() => {
       TD.settings.setUseStream(TD.settings.getUseStream());
       patchContentEditable();

--- a/src/preload.js
+++ b/src/preload.js
@@ -614,10 +614,6 @@ document.addEventListener('DOMContentLoaded', () => {
         f();
       };
     }
-    TD.config.decider_overlay = {};
-    if (config.useOldStyleReply) {
-      TD.config.decider_overlay.simplified_replies = false;
-    }
   });
 
 });

--- a/src/preload_popup.js
+++ b/src/preload_popup.js
@@ -54,13 +54,13 @@ ipcRenderer.on('command', (event, cmd) => {
       document.execCommand('selectall');
       break;
     case 'copyimage':
-      window.TD.controller.progressIndicator.addMessage('Image downloading..');
+      window.toastMessage('Image downloading..');
       const nativeImage = require('electron').nativeImage;
       var request = require('request').defaults({ encoding: null });
       request.get(Addr.img, function (error, response, body) {
         if (!error && response.statusCode === 200) {
           clipboard.writeImage(nativeImage.createFromBuffer(body));
-          window.TD.controller.progressIndicator.addMessage('Image copied to clipboard');
+          window.toastMessage('Image copied to clipboard');
         }
       });
       break;

--- a/src/preload_scripts/autosave-favorites.js
+++ b/src/preload_scripts/autosave-favorites.js
@@ -20,7 +20,7 @@ function download (url, filename) {
     fs.mkdirSync(savepath);
   } catch (error) {
     if (error.code !== 'EEXIST') {
-      window.TD.controller.progressIndicator.addMessage('Failed - Save Image : Cannot make folder');
+      window.toastErrorMessage('Failed - Save Image : Cannot make folder');
       return;
     }
   }
@@ -28,7 +28,7 @@ function download (url, filename) {
   try {
     request(url).pipe(fs.createWriteStream(filepath));
   } catch (e) {
-    window.TD.controller.progressIndicator.addMessage(`Failed - Save Image : Cannot save image to ${filepath}`);
+    window.toastErrorMessage(`Failed - Save Image : Cannot save image to ${filepath}`);
   }
 }
 

--- a/src/preload_scripts/quote-without-notification.js
+++ b/src/preload_scripts/quote-without-notification.js
@@ -45,10 +45,10 @@ function MakeQuoteWithoutNotification (ipcRenderer, id) {
     var quoteUrl = data.url;
     ipcRenderer.send('twtlib-send-text', quoteUrl);
     jq(document).trigger('uiComposeTweet', { type: 'tweet' });
-    TD.controller.progressIndicator.addMessage('Quote link generated');
+    window.toastMessage('Quote link generated');
 
   }).catch(function (err) {
-    TD.controller.progressIndicator.addMessage(err);
+    window.toastErrorMessage(err);
   });
 };
 

--- a/src/preload_scripts/switch-account.js
+++ b/src/preload_scripts/switch-account.js
@@ -20,7 +20,7 @@ function SwitchAccount () {
       accountKeys: [accountKey],
     });
     const message = TD.i('Default Account Switched to {{name}}', { name });
-    TD.controller.progressIndicator.addMessage(message);;
+    window.toastMessage(message);;
   });
 }
 


### PR DESCRIPTION
- 며칠 전에 @perillamint 님이 제보한 `addMessage` 버그 해결 -- 우측하단에 메시지 띄우는 `progressIndicator.addMessage`가 없어지는 대신 새 디자인의 알림 UI에 대응하도록 고침
- "이전 스타일의 답글로 되돌리기" 옵션 제거 -- 트윗덱측에서 완전 제거하여서 해당 기능 구현 불가능. 그래서 옵션 지움