### PR TITLE
기능 추가: 사용자 노트

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "async": "^2.0.1",
     "detect-font": "^0.1.3",
     "jquery": "^3.1.0",
+    "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
     "nouislider": "^8.5.1",
@@ -42,12 +43,12 @@
   },
   "devDependencies": {
     "csscomb": "^3.1.8",
+    "electron": "^1.7.5",
     "electron-packager": "^8.0.0",
     "eslint": "^3.5.0",
     "eslint-plugin-html": "^2.0.1",
     "fs-extra": "^0.30.0",
     "minimist": "^1.2.0",
-    "electron": "^1.7.5",
     "sync-exec": "^0.6.2"
   },
   "scripts": {

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -209,6 +209,12 @@ module.exports = [
     label: 'Clear notification counter periodically',
     description: '<b>Requires reload to apply.</b>',
   },
+  {
+    _type: 'entry',
+    name: 'enableUserNotes',
+    valueType: 'bool',
+    label: 'Enable User note',
+  },
   { _type: 'subsection', label: 'Privacy' },
   {
     _type: 'entry',

--- a/src/config.js
+++ b/src/config.js
@@ -20,7 +20,8 @@ module.exports = {
     enableOpenImageinPopup: 'on',
     useSquareProfileImage: false,
     useCounterClear: false,
-    autoReloadCycle: 12
+    autoReloadCycle: 12,
+    enableUserNotes: false,
   },
   data: {},
   load () {

--- a/src/preload.js
+++ b/src/preload.js
@@ -28,6 +28,7 @@ const ImageViewer = require('./preload_scripts/image-viewer');
 const SwitchAccount = require('./preload_scripts/switch-account');
 const WikiLinkFixer = require('./preload_scripts/wikilinkfix');
 const CounterClear = require('./preload_scripts/counterclear.js');
+const UserNotes = require('./preload_scripts/user-note.js');
 
 // 설정 파일 읽기
 var config = Config.load();
@@ -412,6 +413,8 @@ document.addEventListener('DOMContentLoaded', ImageViewer);
 document.addEventListener('DOMContentLoaded', SwitchAccount);
 document.addEventListener('DOMContentLoaded', WikiLinkFixer);
 document.addEventListener('DOMContentLoaded', CounterClear);
+document.addEventListener('DOMContentLoaded', UserNotes);
+
 
 if (config.enableUnlinkis) {
   document.addEventListener('DOMContentLoaded', Unlinkis);

--- a/src/preload_scripts/user-note.js
+++ b/src/preload_scripts/user-note.js
@@ -1,0 +1,140 @@
+const fs = require('mz/fs');
+const path = require('path');
+const _ = require('lodash');
+const Util = require('../util');
+const insertStyle = require('./playermonkey').GM_addStyle;
+
+const dataPath = Util.getUserDataPath();
+
+const UserNote = {
+  // 설정파일 로드
+  _filePath: path.join(dataPath, '/usernote.json'),
+  async loadFile () {
+    let notes;
+    try {
+      const json = await fs.readFile(this._filePath, 'utf8');
+      notes = JSON.parse(json);
+    } catch (e) {
+      notes = {};
+    }
+    return notes;
+  },
+  saveFile (newData) {
+    const json = JSON.stringify(newData, null, 2);
+    return fs.writeFileSync(this._filePath, json, 'utf8');
+  },
+  async load (userID) {
+    const notes = await this.loadFile();
+    const note = String(notes[userID] || '').trim();
+    return note;
+  },
+  // 설정파일 저장
+  async save (userID, newnote) {
+    const notes = await this.loadFile();
+    notes[userID] = newnote;
+    return this.saveFile(notes);
+  },
+};
+
+class UserNoteUI {
+  constructor (root) {
+    this.root = root;
+    this.textarea = root.querySelector('textarea.user-note-area');
+    this.loading = root.querySelector('.user-note-loading');
+    const inputListener = event => {
+      const newNote = this.textarea.value;
+      UserNote.save(this.currentUserID, newNote);
+    };
+    this.textarea.addEventListener('input', _.debounce(inputListener, 200));
+  }
+  async load (userID) {
+    const { textarea, loading } = this;
+    textarea.disabled = true;
+    loading.classList.remove('loaded');
+    this.currentUserID = userID;
+    //debugger;
+    const note = await UserNote.load(userID);
+    textarea.value = note;
+    textarea.disabled = false;
+    loading.classList.add('loaded');
+  }
+  //save () {}
+}
+
+// ======================================================================
+
+// 트위터상에서 유저네임은 자유롭게 바꿀 수 있으므로
+// 노트는 유저네임 대신 ID를 기준으로 하여 작성함
+
+// 트위터 프로필 modal에 사용자 고유 ID를 포함하게 만듦
+const TEMPLATE_HACK_HTML = `
+  {{#twitterProfile}}
+    {{#profile}}
+      <span hidden class="user-id" style="display:none">
+        {{id}}
+      </span>
+    {{/profile}}
+  {{/twitterProfile}}
+`;
+
+const USER_NOTE_HTML = `
+  <div id="user-note-app">
+    <div class="user-note-control">
+      User Note: <span class="user-note-loading">(Loading...)</span>
+    </div>
+    <textarea class="user-note-area" placeholder="여기에 사용자별 노트를 작성할 수 있습니다. 여기에 적은 내용은 다른 트위터 유저에게 노출되지 않습니다.">
+    </textarea>
+  </div>
+`;
+
+const USER_NOTE_CSS = `
+  #user-note-app {
+    padding: 3px;
+    font-size: 12pt;
+    background-color: #e1e8ed;
+    color: #292f33;
+  }
+  .user-note-area {
+    height: 80px;
+  }
+  .user-note-control {
+    margin: 3px;
+    font-size: 10pt;
+  }
+  .user-note-loading.loaded {
+    display: none;
+  }
+`;
+
+module.exports = () => {
+  insertStyle(USER_NOTE_CSS);
+  window.TD_mustaches['twitter_profile.mustache'] += TEMPLATE_HACK_HTML;
+  const observeMe = document.querySelector('.js-modals-container');
+  const observer = new MutationObserver(mutations => {
+    for (const mut of mutations) {
+      for (const node of mut.addedNodes) {
+        if (!node.className) continue;
+        if (document.getElementById('user-note-app')) continue;
+        let userID;
+        const userIDElement = node.querySelector('.user-id');
+        if (node.matches('.user-id')) {
+          userID = node.textContent.trim();
+        } else if (userIDElement) {
+          userID = userIDElement.textContent.trim();
+        }
+        if (!userID) continue;
+        const appContainer = document.createElement('div');
+        appContainer.innerHTML = USER_NOTE_HTML;
+        window.$('.prf-header').after(appContainer);
+        const app = new UserNoteUI(appContainer);
+        app.load(userID);
+      }
+    }
+  });
+  observer.observe(observeMe, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  });
+};

--- a/src/preload_scripts/user-note.js
+++ b/src/preload_scripts/user-note.js
@@ -2,8 +2,10 @@ const fs = require('mz/fs');
 const path = require('path');
 const _ = require('lodash');
 const Util = require('../util');
+const Config = require('../config');
 const insertStyle = require('./playermonkey').GM_addStyle;
 
+const config = Config.load();
 const dataPath = Util.getUserDataPath();
 
 const UserNote = {
@@ -111,6 +113,9 @@ module.exports = () => {
   window.TD_mustaches['twitter_profile.mustache'] += TEMPLATE_HACK_HTML;
   const observeMe = document.querySelector('.js-modals-container');
   const observer = new MutationObserver(mutations => {
+    if (!config.enableUserNotes) {
+      return;
+    }
     for (const mut of mutations) {
       for (const node of mut.addedNodes) {
         if (!node.className) continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/node@^7.0.18":
-  version "7.0.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.31.tgz#80ea4d175599b2a00149c29a10a4eb2dff592e86"
+"@types/node@^8.0.24":
+  version "8.0.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"
 
 abbrev@1:
   version "1.1.0"
@@ -479,11 +479,11 @@ electron-packager@^8.0.0:
     sanitize-filename "^1.6.0"
     semver "^5.3.0"
 
-electron@^1.6.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.3.tgz#839cab0a0598835a100dceede215988ba99c325b"
+electron@^1.7.5:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.0.tgz#896f429b1e664f496f62b9cc7ee6a67a71375f31"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
@@ -1163,7 +1163,7 @@ lodash.get@^4.0.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/830515/29998870-d0f6c5c4-9070-11e7-9d87-df5a2cc84162.png)

기억하고 싶은 내용(팔로우/뮤트/블락한 이유, 이전에 사용하던 닉네임, 이벤트 등)을 사용자별로 적을 수 있는 기능. Tweetbot, Hootsuite 등 일부 트위터 클라이언트에서 제공하는 기능을 비슷하게 구현함.